### PR TITLE
fix: ensure contract is used over collection in dynamoc indexes

### DIFF
--- a/ark-dynamodb/src/providers/event/dynamo_provider.rs
+++ b/ark-dynamodb/src/providers/event/dynamo_provider.rs
@@ -126,7 +126,7 @@ impl ArkEventProvider for DynamoDbEventProvider {
             .item("Type".to_string(), AttributeValue::S("Event".to_string()))
             .item(
                 "GSI1PK".to_string(),
-                AttributeValue::S(format!("COLLECTION#{}", event.contract_address)),
+                AttributeValue::S(format!("CONTRACT#{}", event.contract_address)),
             )
             .item(
                 "GSI1SK".to_string(),

--- a/ark-dynamodb/src/providers/token/dynamo_provider.rs
+++ b/ark-dynamodb/src/providers/token/dynamo_provider.rs
@@ -232,7 +232,7 @@ impl ArkTokenProvider for DynamoDbTokenProvider {
             .item("Type".to_string(), AttributeValue::S("Token".to_string()))
             .item(
                 "GSI1PK".to_string(),
-                AttributeValue::S(format!("COLLECTION#{}", info.contract_address)),
+                AttributeValue::S(format!("CONTRACT#{}", info.contract_address)),
             )
             .item(
                 "GSI1SK".to_string(),


### PR DESCRIPTION
## Description

Quick fix of typo where `COLLECTION` was not replaced by `CONTRACT` for dynamodb
indexes.

## What type of PR is this? (check all applicable)

- [X] 🐛 Bug Fix (`fix:`)
