### PR TITLE
fix(ark-dynamodb): add index to contracts to identify nft collections

### DIFF
--- a/ark-dynamodb/src/providers/contract/dynamo_provider.rs
+++ b/ark-dynamodb/src/providers/contract/dynamo_provider.rs
@@ -76,6 +76,12 @@ impl ArkContractProvider for DynamoDbContractProvider {
 
         debug!("Registering contract with PK: {} and SK: {}", pk, sk);
 
+        let gsi2pk = match info.contract_type.as_str() {
+            "ERC721" => String::from("NFT"),
+            "ERC1155" => String::from("NFT"),
+            _ => String::from("OTHER"),
+        };
+
         let r = ctx
             .client
             .put_item()
@@ -86,13 +92,10 @@ impl ArkContractProvider for DynamoDbContractProvider {
             // is required. So we duplicate info in the GSI1. TODO: investiagte more.
             .item("GSI1PK".to_string(), AttributeValue::S(sk.clone()))
             .item("GSI1SK".to_string(), AttributeValue::S(pk.clone()))
-            .item(
-                "GSI2PK".to_string(),
-                AttributeValue::S("CONTRACT".to_string()),
-            )
+            .item("GSI2PK".to_string(), AttributeValue::S(gsi2pk))
             .item(
                 "GSI2SK".to_string(),
-                AttributeValue::S(info.contract_type.clone()),
+                AttributeValue::S(block_timestamp.to_string()),
             )
             .item(
                 "GSI4PK".to_string(),


### PR DESCRIPTION
## Description

Insert a new index (GSI2) to identify nft collections only

## What type of PR is this? (check all applicable)

- [X] 🐛 Bug Fix (`fix:`)

## Related Tickets & Documents

https://screenshot.fibery.io/favorites/@my-space/My-Work-435#Product_Management/Issue/Add-contract-type-index-to-dynamodb-116

## Added tests?

- [X] 🙅 no, because they aren't needed

## Added to documentation?

- [X] 🙅 no documentation needed
