### PR TITLE
feat(ark-dynamodb): handle error during metadata status update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "ark-metadata"
 version = "0.1.0"
-source = "git+https://github.com/ArkProjectNFTs/ark-project?tag=v0.6.2#0dfcde6574d6cf3269c000a6ececbdef2dc1acd5"
+source = "git+https://github.com/ArkProjectNFTs/ark-project?tag=v0.7.0#09786a0b454dda9f1ec982d7284a6bdb25bb7d99"
 dependencies = [
  "anyhow",
  "ark-starknet",
@@ -272,7 +272,7 @@ dependencies = [
 [[package]]
 name = "ark-starknet"
 version = "0.1.0"
-source = "git+https://github.com/ArkProjectNFTs/ark-project?tag=v0.6.2#0dfcde6574d6cf3269c000a6ececbdef2dc1acd5"
+source = "git+https://github.com/ArkProjectNFTs/ark-project?tag=v0.7.0#09786a0b454dda9f1ec982d7284a6bdb25bb7d99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -298,7 +298,7 @@ dependencies = [
 [[package]]
 name = "arkproject"
 version = "0.1.0"
-source = "git+https://github.com/ArkProjectNFTs/ark-project?tag=v0.6.2#0dfcde6574d6cf3269c000a6ececbdef2dc1acd5"
+source = "git+https://github.com/ArkProjectNFTs/ark-project?tag=v0.7.0#09786a0b454dda9f1ec982d7284a6bdb25bb7d99"
 dependencies = [
  "anyhow",
  "ark-metadata",
@@ -1412,7 +1412,7 @@ dependencies = [
 [[package]]
 name = "diri"
 version = "0.1.0"
-source = "git+https://github.com/ArkProjectNFTs/ark-project?tag=v0.6.2#0dfcde6574d6cf3269c000a6ececbdef2dc1acd5"
+source = "git+https://github.com/ArkProjectNFTs/ark-project?tag=v0.7.0#09786a0b454dda9f1ec982d7284a6bdb25bb7d99"
 dependencies = [
  "anyhow",
  "ark-starknet",
@@ -2948,7 +2948,7 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 [[package]]
 name = "pontos"
 version = "0.1.0"
-source = "git+https://github.com/ArkProjectNFTs/ark-project?tag=v0.6.2#0dfcde6574d6cf3269c000a6ececbdef2dc1acd5"
+source = "git+https://github.com/ArkProjectNFTs/ark-project?tag=v0.7.0#09786a0b454dda9f1ec982d7284a6bdb25bb7d99"
 dependencies = [
  "anyhow",
  "ark-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 [workspace.dependencies]
 anyhow = "1.0"
 ark-dynamodb = { path = "ark-dynamodb" }
-arkproject = { git = "https://github.com/ArkProjectNFTs/ark-project", tag = "v0.6.2" }
+arkproject = { git = "https://github.com/ArkProjectNFTs/ark-project", tag = "v0.7.0" }
 # arkproject = { path = "../ark-project" }
 async-trait = "0.1.73"
 lambda-http-common = { path = "ark-lambdas/apigw/lambda-http-common" }

--- a/ark-dynamodb/src/metadata_storage.rs
+++ b/ark-dynamodb/src/metadata_storage.rs
@@ -36,6 +36,32 @@ impl MetadataStorage {
 
 #[async_trait]
 impl Storage for MetadataStorage {
+    async fn update_token_metadata_status(
+        &self,
+        contract_address: FieldElement,
+        token_id: CairoU256,
+        metadata_status: &str,
+    ) -> Result<(), StorageError> {
+        let token_id_hex = token_id.to_hex();
+        let contract_address_hex = format!("0x{:064x}", contract_address);
+
+        self.provider
+            .token
+            .update_token_metadata_status(
+                &self.ctx,
+                &contract_address_hex,
+                &token_id_hex,
+                metadata_status,
+            )
+            .await
+            .map_err(|e| {
+                error!("Failed to update token metadata status. Error: {}", e);
+                StorageError::DatabaseError(e.to_string())
+            })?;
+
+        Ok(())
+    }
+
     async fn register_token_metadata(
         &self,
         contract_address: &FieldElement,

--- a/ark-dynamodb/src/providers/token/mod.rs
+++ b/ark-dynamodb/src/providers/token/mod.rs
@@ -46,6 +46,14 @@ pub trait ArkTokenProvider {
         metadata: &TokenMetadata,
     ) -> Result<DynamoDbOutput<()>, ProviderError>;
 
+    async fn update_token_metadata_status(
+        &self,
+        ctx: &DynamoDbCtx,
+        contract_address: &str,
+        token_id_hex: &str,
+        metadata_status: &str,
+    ) -> Result<DynamoDbOutput<()>, ProviderError>;
+
     async fn get_token(
         &self,
         ctx: &DynamoDbCtx,

--- a/ark-indexer/src/aws_s3_file_manager.rs
+++ b/ark-indexer/src/aws_s3_file_manager.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use arkproject::metadata::file_manager::{FileInfo, FileManager};
 use async_trait::async_trait;
 use aws_sdk_s3::primitives::ByteStream;
-use tracing::debug;
+use tracing::{debug, error, info};
 
 /// FileManager implementation that saves files to AWS S3.
 ///
@@ -24,25 +24,63 @@ impl AWSFileManager {
 #[async_trait]
 impl FileManager for AWSFileManager {
     async fn save(&self, file: &FileInfo) -> Result<()> {
-        debug!("Uploading {} to AWS...", file.name);
+        info!(
+            "Starting upload of '{}' to AWS S3 bucket '{}'.",
+            file.name, &self.bucket_name
+        );
 
         let config = aws_config::load_from_env().await;
         let client = aws_sdk_s3::Client::new(&config);
         let body = ByteStream::from(file.content.clone());
-
         let key = match &file.dir_path {
-            Some(dir_path) => format!("{}/{}", dir_path, &file.name),
-            None => file.name.clone(),
+            Some(dir_path) => {
+                debug!(
+                    "Resolved directory path for '{}': '{}'.",
+                    file.name, dir_path
+                );
+                format!("{}/{}", dir_path, &file.name)
+            }
+            None => {
+                debug!(
+                    "No directory path provided for '{}'. Using filename as key.",
+                    file.name
+                );
+                file.name.clone()
+            }
         };
 
-        let _ = client
+        debug!(
+            "Preparing to upload to Bucket='{}', Key='{}'.",
+            &self.bucket_name, &key
+        );
+
+        match client
             .put_object()
             .bucket(&self.bucket_name)
-            .key(key)
+            .key(&key)
             .body(body)
             .send()
-            .await?;
-
-        Ok(())
+            .await
+        {
+            Ok(_) => {
+                info!(
+                    "Successfully uploaded '{}' to AWS S3 bucket '{}'.",
+                    file.name, &self.bucket_name
+                );
+                Ok(())
+            }
+            Err(e) => {
+                error!(
+                    "Upload failure for '{}' to AWS S3 bucket '{}': {}",
+                    file.name, &self.bucket_name, e
+                );
+                Err(anyhow::anyhow!(
+                    "Failed to upload '{}' to AWS S3 bucket '{}': {}",
+                    file.name,
+                    &self.bucket_name,
+                    e
+                ))
+            }
+        }
     }
 }

--- a/ark-metadata-refresh/src/main.rs
+++ b/ark-metadata-refresh/src/main.rs
@@ -1,84 +1,95 @@
 mod aws_s3_file_manager;
 
+use crate::aws_s3_file_manager::AWSFileManager;
 use anyhow::Result;
 use ark_dynamodb::metadata_storage::MetadataStorage;
 use arkproject::{
     metadata::{
-        metadata_manager::{ImageCacheOption, MetadataManager},
+        metadata_manager::{ImageCacheOption, MetadataError, MetadataManager},
         storage::Storage,
     },
     starknet::client::{StarknetClient, StarknetClientHttp},
 };
-use core::panic;
 use dotenv::dotenv;
 use starknet::core::types::FieldElement;
 use std::{env, time::Duration};
 use tokio::time::sleep;
-use tracing::{error, info, span, Level};
+use tracing::{debug, error, info, span, trace, warn, Level};
 use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Registry};
 
-use crate::aws_s3_file_manager::AWSFileManager;
+struct Config {
+    table_name: String,
+    bucket_name: String,
+    rpc_url: String,
+    ipfs_timeout_duration: Duration,
+    loop_delay_duration: Duration,
+    ipfs_gateway_uri: String,
+    contract_address_filter: Option<FieldElement>,
+}
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn get_env_variables() -> Config {
     dotenv().ok();
-    init_tracing();
-    let table_name: String =
-        env::var("INDEXER_TABLE_NAME").expect("INDEXER_TABLE_NAME must be set");
+
+    let table_name = env::var("INDEXER_TABLE_NAME").expect("INDEXER_TABLE_NAME must be set");
     let bucket_name =
         env::var("AWS_NFT_IMAGE_BUCKET_NAME").expect("AWS_NFT_IMAGE_BUCKET_NAME must be set");
     let rpc_url = env::var("RPC_PROVIDER").expect("RPC_PROVIDER must be set");
 
-    let ipfs_timeout_duration = match env::var("METADATA_IPFS_TIMEOUT_IN_SEC") {
-        Ok(value) => {
-            let timeout = value
-                .parse::<u64>()
-                .expect("Invalid METADATA_IPFS_TIMEOUT_IN_SEC");
-            Duration::from_secs(timeout)
-        }
-        Err(_) => {
-            panic!("METADATA_IPFS_TIMEOUT_IN_SEC must be set");
-        }
-    };
+    let ipfs_timeout_duration = Duration::from_secs(
+        env::var("METADATA_IPFS_TIMEOUT_IN_SEC")
+            .expect("METADATA_IPFS_TIMEOUT_IN_SEC must be set")
+            .parse::<u64>()
+            .expect("Invalid METADATA_IPFS_TIMEOUT_IN_SEC"),
+    );
 
-    let loop_delay_duration = match env::var("METADATA_LOOP_DELAY_IN_SEC") {
-        Ok(value) => {
-            let timeout = value
-                .parse::<u64>()
-                .expect("Invalid METADATA_LOOP_DELAY_IN_SEC");
-            Duration::from_secs(timeout)
-        }
-        Err(_) => {
-            panic!("METADATA_LOOP_DELAY_IN_SEC must be set");
-        }
-    };
-
-    let metadata_storage = MetadataStorage::new(table_name).await;
-    let starknet_client = StarknetClientHttp::new(&rpc_url)?;
-    let file_manager = AWSFileManager::new(bucket_name);
+    let loop_delay_duration = Duration::from_secs(
+        env::var("METADATA_LOOP_DELAY_IN_SEC")
+            .expect("METADATA_LOOP_DELAY_IN_SEC must be set")
+            .parse::<u64>()
+            .expect("Invalid METADATA_LOOP_DELAY_IN_SEC"),
+    );
 
     let ipfs_gateway_uri = env::var("IPFS_GATEWAY_URI").expect("IPFS_GATEWAY_URI must be set");
+
+    let contract_address_filter = env::var("METADATA_CONTRACT_FILTER")
+        .ok()
+        .map(|value| FieldElement::from_hex_be(&value).expect("Invalid METADATA_CONTRACT_FILTER"));
+
+    Config {
+        table_name,
+        bucket_name,
+        rpc_url,
+        ipfs_timeout_duration,
+        loop_delay_duration,
+        ipfs_gateway_uri,
+        contract_address_filter,
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    init_tracing();
+    let config = get_env_variables();
+    let metadata_storage = MetadataStorage::new(config.table_name.clone()).await;
+    let starknet_client = StarknetClientHttp::new(&config.rpc_url)?;
+    let file_manager = AWSFileManager::new(config.bucket_name);
+
+    trace!("Initialized AWSFileManager, StarknetClientHttp, and MetadataStorage");
+
     let mut metadata_manager =
         MetadataManager::new(&metadata_storage, &starknet_client, &file_manager);
 
-    let contract_address_filter = match env::var("METADATA_CONTRACT_FILTER") {
-        Ok(value) => {
-            let contract_address_field_element = FieldElement::from_hex_be(value.as_str())
-                .expect("Invalid METADATA_CONTRACT_FILTER");
-            Some(contract_address_field_element)
-        }
-        Err(_) => None,
-    };
+    debug!("Starting main loop to check and refresh token metadata");
 
     loop {
         match metadata_storage
-            .find_token_ids_without_metadata(contract_address_filter)
+            .find_token_ids_without_metadata(config.contract_address_filter)
             .await
         {
             Ok(tokens) => {
                 if tokens.is_empty() {
-                    info!("No tokens to refresh (without metadata)");
-                    sleep(loop_delay_duration).await;
+                    info!("No tokens found that require metadata refresh");
+                    sleep(config.loop_delay_duration).await;
                     continue;
                 } else {
                     for token in tokens {
@@ -93,15 +104,37 @@ async fn main() -> Result<()> {
                         match metadata_manager
                             .refresh_token_metadata(
                                 contract_address,
-                                token_id,
+                                token_id.clone(),
                                 ImageCacheOption::Save,
-                                ipfs_gateway_uri.as_str(),
-                                ipfs_timeout_duration,
+                                config.ipfs_gateway_uri.as_str(),
+                                config.ipfs_timeout_duration,
                             )
                             .await
                         {
-                            Ok(_) => info!("✅ Metadata refreshed successfully"),
-                            Err(e) => error!("Error: {:?}", e),
+                            Ok(_) => {
+                                info!(
+                                    "✅ Metadata for Token ID: {} refreshed successfully",
+                                    token_id.to_decimal(false)
+                                );
+                            }
+                            Err(metadata_error) => {
+                                match metadata_error {
+                                    MetadataError::ParsingError(error) => {
+                                        warn!("❌ Parsing error: {:?}", error);
+                                    }
+                                    e => {
+                                        error!("❌ Error: {:?}", e);
+                                    }
+                                }
+
+                                let _ = metadata_storage
+                                    .update_token_metadata_status(
+                                        contract_address,
+                                        token_id.clone(),
+                                        "ERROR",
+                                    )
+                                    .await;
+                            }
                         }
                     }
                     continue;
@@ -109,7 +142,7 @@ async fn main() -> Result<()> {
             }
             Err(e) => {
                 error!("Error: {:?}", e);
-                sleep(loop_delay_duration).await;
+                sleep(config.loop_delay_duration).await;
                 continue;
             }
         };


### PR DESCRIPTION
## Description

### Challenge
There's an ongoing issue with managing metadata errors, especially with some defective IPFS links that repeatedly cause failures. Due to the lack of METADATA status updates, these faulty records are redundantly processed in every cycle, posing a risk of augmented latency if such errors accumulate.

### Proposed Fix
To mitigate this, we plan to modify the token in DynamoDB, marking it with a 'metadata error' status. This will ensure such tokens aren't re-indexed, eliminating unnecessary reprocessing.

## What type of PR is this? (check all applicable)

- [X] 🍕 Feature (`feat:`)

## Related Tickets & Documents

https://screenshot.fibery.io/@my-space/My-Work-435#Product_Management/Issue/Handle-Metadata-Errors-to-Prevent-Re-Indexing-37

## Added tests?

- [X] 🙅 no, because they aren't needed

## Added to documentation?

- [X] 🙅 no documentation needed
