### PR TITLE
fix(ark-dynamodb): add gsi6 to block data

### DIFF
--- a/ark-dynamodb/src/providers/block/dynamo_provider.rs
+++ b/ark-dynamodb/src/providers/block/dynamo_provider.rs
@@ -96,6 +96,14 @@ impl ArkBlockProvider for DynamoDbBlockProvider {
                 "GSI1SK".to_string(),
                 AttributeValue::S(self.get_pk(block_timestamp)),
             )
+            .item(
+                "GSI6PK".to_string(),
+                AttributeValue::S(String::from("BLOCK")),
+            )
+            .item(
+                "GSI6SK".to_string(),
+                AttributeValue::N(block_number.to_string()),
+            )
             .item("Data", AttributeValue::M(data))
             .item("Type", AttributeValue::S(EntityType::Block.to_string()))
             .return_consumed_capacity(ReturnConsumedCapacity::Total)


### PR DESCRIPTION
# Overview

The idea of this pull request is to allow for an index to sort the blocks by block id instead of timestamp (as it is currently the case). This currently poses problems, particularly for the [indexer app](https://indexer.arkproject.dev)  in identifying unindexed blocks, as some blocks were produced with the same timestamp (which should not have happened...)